### PR TITLE
Update maven pom file to not rely on settings.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <url>http://maven.apache.org</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flume.version>1.1.0-cdh4.0.0b2</flume.version>
+        <flume.version>1.1.0-cdh4.0.0</flume.version>
 	<rabbitmq.version>2.8.2</rabbitmq.version>
         <junit.version>4.10</junit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
I updated the pom to include the cloudera repository and update the flume version.  It now builds without relying on a settings.xml file.
