### PR TITLE
Setting _Consumer=null on connection/channel reset

### DIFF
--- a/src/main/java/org/apache/flume/source/rabbitmq/RabbitMQSource.java
+++ b/src/main/java/org/apache/flume/source/rabbitmq/RabbitMQSource.java
@@ -79,6 +79,7 @@ public class RabbitMQSource extends AbstractSource implements Configurable, Poll
         RabbitMQUtil.close(_Connection, _Channel);
         _Connection=null;
         _Channel=null;
+        _Consumer=null;
     }
     
     @Override
@@ -102,7 +103,7 @@ public class RabbitMQSource extends AbstractSource implements Configurable, Poll
                 _Channel = _Connection.createChannel();
                 _CounterGroup.incrementAndGet(RabbitMQConstants.COUNTER_NEW_CHANNEL);
                 if(log.isInfoEnabled())log.info(this.getName() + " - Connected to " + _ConnectionFactory.getHost() + ":" + _ConnectionFactory.getPort());
-                
+                _Consumer=null;
                 if( StringUtils.isNotEmpty(_ExchangeName) ) {
                 	try {
         	        	//declare an exchange


### PR DESCRIPTION
Related to the issue I opened, this is the fix that I've used in order to handle resetting the _Consumer after resetting the connection/channel